### PR TITLE
[suturo_map] new-friendly-publishing-method

### DIFF
--- a/src/suturo_resources/suturo_map.py
+++ b/src/suturo_resources/suturo_map.py
@@ -326,17 +326,3 @@ class Publisher:
 
     def publish(self, world):
         viz = VizMarkerPublisher(world=world, node=self.node)
-
-
-def published(world: World):
-    """
-    Initializes ROS2 node and starts publishing the environment's visual representation for visualization in RViz.
-    Runs in a separate thread, enabling real-time visualization.
-    """
-    rclpy.init()
-    node = rclpy.create_node("semantic_digital_twin")
-    thread = threading.Thread(target=rclpy.spin, args=(node,), daemon=True)
-    thread.start()
-
-publisher = Publisher("semantic_digital_twin")
-publisher.publish(load_environment())


### PR DESCRIPTION
removed unused published function and redundant threading logic in semantic_digital_twin.

to spawn the map just add:
publisher = Publisher("semantic_digital_twin")
publisher.publish(world)

to the test_load_environment_returns_world test and run it.