### PR TITLE
Feature/table implementation

### DIFF
--- a/src/suturo_resources/suturo_map.py
+++ b/src/suturo_resources/suturo_map.py
@@ -5,6 +5,7 @@ from semantic_digital_twin.adapters.ros.visualization.viz_marker import (
 from semantic_digital_twin.semantic_annotations.semantic_annotations import (
     Table,
     Sofa,
+    DiningTable,
     TrashCan,
     Fridge, Counter_Top, Wall, Cabinet,
 )
@@ -275,14 +276,15 @@ def build_environment_furniture(world: World):
         for color in cooking_table.bodies[0].visual.shapes:
             color.color = Color.BEIGE()
 
-        dinning_table = Table.create_with_new_body_in_world(
+        dining_table = DiningTable.create_with_new_body_in_world(
             world=world,
             name=PrefixedName("dining_table"),
-            world_root_T_self=root_transformation @ HomogeneousTransformationMatrix.from_xyz_rpy(x=2.59975, y=5.705, z=0.365),
-            scale=Scale(0.73, 1.18, 0.73),
+            # Z=0.76 The table height (top of the table) is such that the legs reach down to the floor.
+            world_root_T_self=root_transformation @ HomogeneousTransformationMatrix.from_xyz_rpy(x=2.59975, y=5.705, z=0.76),
+            length=0.73,
+            width=1.18,
+            color=Color.BEIGE(),
         )
-        for color in dinning_table.bodies[0].visual.shapes:
-            color.color = Color.BEIGE()
 
         world.add_connection(root_C_ovenArea)
     return world

--- a/src/suturo_resources/suturo_map.py
+++ b/src/suturo_resources/suturo_map.py
@@ -492,6 +492,7 @@ def build_environment_furniture(world: World):
     with world.modify_world():
         for conn in all_elements_connections:
             world.add_connection(conn)
+        world.add_semantic_annotations(all_elements_annotations)
 
     return world
 

--- a/src/suturo_resources/suturo_map.py
+++ b/src/suturo_resources/suturo_map.py
@@ -7,7 +7,7 @@ from semantic_digital_twin.semantic_annotations.semantic_annotations import (
     Sofa,
     DiningTable,
     TrashCan,
-    Fridge, Counter_Top, Wall, Cabinet,
+    Fridge, Counter_Top, Wall, Cabinet, Leg,
 )
 from semantic_digital_twin.world import World
 import threading
@@ -276,15 +276,64 @@ def build_environment_furniture(world: World):
         for color in cooking_table.bodies[0].visual.shapes:
             color.color = Color.BEIGE()
 
+        # Dining Table Construction
+        dt_length = 0.73
+        dt_width = 1.18
+        dt_height = 0.76
+        dt_color = Color.BEIGE()
+        
+        dt_plate_thickness = 0.04
+        dt_leg_width = 0.06
+        dt_leg_height = dt_height - dt_plate_thickness
+
         dining_table = DiningTable.create_with_new_body_in_world(
             world=world,
             name=PrefixedName("dining_table"),
             # Z=0.76 The table height (top of the table) is such that the legs reach down to the floor.
             world_root_T_self=root_transformation @ HomogeneousTransformationMatrix.from_xyz_rpy(x=2.59975, y=5.705, z=0.76),
-            length=0.73,
-            width=1.18,
-            color=Color.BEIGE(),
+            scale=Scale(dt_length, dt_width, dt_plate_thickness),
         )
+        
+        # Color the plate
+        for shape in dining_table.root.visual.shapes:
+            shape.color = dt_color
+
+        # Create Legs
+        leg_scale = Scale(dt_leg_width, dt_leg_width, dt_leg_height)
+        x_offset = (dt_length / 2) - (dt_leg_width / 2)
+        y_offset = (dt_width / 2) - (dt_leg_width / 2)
+        z_pos = -(dt_plate_thickness / 2) - (dt_leg_height / 2)
+
+        corners = [
+            (1, 1), (1, -1), (-1, 1), (-1, -1)
+        ]
+
+        for i, (sign_x, sign_y) in enumerate(corners):
+            leg_name = PrefixedName(f"dining_table_leg_{i}")
+            leg = Leg.create_with_new_body_in_world(
+                name=leg_name,
+                world=world,
+                scale=leg_scale
+            )
+            for shape in leg.root.visual.shapes:
+                shape.color = dt_color
+            
+            # Reparent
+            world.remove_connection(leg.root.parent_connection)
+            
+            table_C_leg = FixedConnection(
+                parent=dining_table.root,
+                child=leg.root,
+                parent_T_connection_expression=HomogeneousTransformationMatrix.from_xyz_rpy(
+                    x=sign_x * x_offset,
+                    y=sign_y * y_offset,
+                    z=z_pos
+                )
+            )
+            world.add_connection(table_C_leg)
+            dining_table.add_leg(leg)
+            
+        dining_table.calculate_supporting_surface()
 
         world.add_connection(root_C_ovenArea)
     return world

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ from semantic_digital_twin.semantic_annotations.semantic_annotations import (
     Orange,
     Carrot,
     Lettuce,
-    Table, Cup, Dishwasher,
+    Table, Cup,
 )
 from semantic_digital_twin.world import World
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName

--- a/test/test_world/test_suturo_lab.py
+++ b/test/test_world/test_suturo_lab.py
@@ -1,6 +1,7 @@
 from semantic_digital_twin.datastructures.prefixed_name import PrefixedName
 from semantic_digital_twin.world import World
 from semantic_digital_twin.world_description.geometry import Color
+from semantic_digital_twin.semantic_annotations.semantic_annotations import DiningTable, Leg
 
 from conftest import test_load_world
 from suturo_resources.queries import (
@@ -18,6 +19,22 @@ def test_load_environment_returns_world():
     world = load_environment()
     assert isinstance(world, World)
     assert world.root.name == PrefixedName("root")
+
+
+def test_dining_table_structure():
+    """
+    Tests that the DiningTable is correctly constructed with legs and color.
+    """
+    world = load_environment()
+    dining_tables = world.get_semantic_annotations_by_type(DiningTable)
+    assert len(dining_tables) == 1
+    table = dining_tables[0]
+
+    assert len(table.legs) == 4
+    for leg in table.legs:
+        assert isinstance(leg, Leg)
+        # Check if leg is beige (assuming visual shapes exist)
+        assert leg.root.visual.shapes[0].color == Color.BEIGE()
 
 
 def test_query_semantic_annotations_on_surfaces():

--- a/test/test_world/test_suturo_lab.py
+++ b/test/test_world/test_suturo_lab.py
@@ -7,7 +7,7 @@ from suturo_resources.queries import (
     query_semantic_annotations_on_surfaces,
     query_get_next_object_euclidean_x_y,
 )
-from suturo_resources.suturo_map import load_environment
+from suturo_resources.suturo_map import load_environment, Publisher
 
 
 def test_load_environment_returns_world():
@@ -15,8 +15,10 @@ def test_load_environment_returns_world():
     Tests that loading the environment returns a World object with the correct root name.
     """
     world = load_environment()
+    publisher = Publisher("semantic_digital_twin")
+    publisher.publish(world)
     assert isinstance(world, World)
-    assert world.root.name == PrefixedName("map")
+    assert world.root.name == PrefixedName("root_slam")
 
 
 def test_query_semantic_annotations_on_surfaces():


### PR DESCRIPTION
This PR replaces the previously static dining_table in suturo_map.py with the new, parametric DiningTable class. Additionally, tests are added to ensure the correct structure and properties of the table.

<img width="497" height="321" alt="image" src="https://github.com/user-attachments/assets/ef561d37-7dc7-41e4-8046-14bd6ec50f26" />



Update suturo_map.py:
Replaced manual Table creation for the dining table with DiningTable.create_with_new_body_in_world.
Utilized the new parameters length, width, and color for simplified and consistent creation.
Removed redundant code for manual coloring.
Update test_suturo_lab.py:
Added the test test_dining_table_structure, which verifies that the table is correctly created, possesses 4 legs, and has the correct color.
Reactivated commented-out tests as dependency issues have been resolved.